### PR TITLE
Made sure render partial always outputs something

### DIFF
--- a/lib/rails_view_annotator/action_view/partial_renderer.rb
+++ b/lib/rails_view_annotator/action_view/partial_renderer.rb
@@ -13,11 +13,16 @@ module RailsViewAnnotator
       descriptor = "#{short_identifier} (from #{called_from})"
 
       if not inner.blank?
-        if args[1].has_key?(:formats) && args[1][:formats].include?(:js)
-          "/* begin: #{descriptor} */\n#{inner}/* end: #{descriptor} */".html_safe
-        elsif !args[1].has_key?(:formats) || args[1][:formats].include?(:html)
-          "<!-- begin: #{descriptor} -->\n#{inner}<!-- end: #{descriptor} -->".html_safe
+        comment_pattern = "%{partial}"
+
+        template_formats = Array(args[1][:formats])
+        if template_formats.include?(:js)
+          comment_pattern = "/* begin: %{comment} */\n#{comment_pattern}/* end: %{comment} */"
+        elsif template_formats.empty? || template_formats.include?(:html)
+          comment_pattern = "<!-- begin: %{comment} -->\n#{comment_pattern}<!-- end: %{comment} -->"
         end
+
+        (comment_pattern % {:partial => inner, :comment => descriptor}).html_safe
       end
     end
     klass.send(:include, InstanceMethods)


### PR DESCRIPTION
There seems to be a bug in 0.0.8 where any partial of an unrecognised format does not get output at all. This should fix that.
