### PR TITLE
Do not annotate plaintext renders

### DIFF
--- a/lib/rails_view_annotator/action_view/partial_renderer.rb
+++ b/lib/rails_view_annotator/action_view/partial_renderer.rb
@@ -1,9 +1,17 @@
 module RailsViewAnnotator
+  # Tells for which formats the partial has been requested.
+  def self.extract_requested_formats_from(render_arguments)
+    lookup_context = render_arguments[0].lookup_context
+    lookup_context.formats
+  end
+  
   def self.augment_partial_renderer klass
-    render = klass.instance_method :render
+    stock_render = klass.instance_method :render
     klass.send(:define_method, :render) do |*args|
-      inner = render.bind(self).call(*args)
+      inner = stock_render.bind(self).call(*args)
+      
       return unless identifier
+      
       short_identifier = Pathname.new(identifier).relative_path_from Rails.root
 
       r = /^#{Regexp.escape(Rails.root.to_s)}\/([^:]+:\d+)/
@@ -12,11 +20,12 @@ module RailsViewAnnotator
 
       descriptor = "#{short_identifier} (from #{called_from})"
 
-      if not inner.blank?
+      if inner.present?
         comment_pattern = "%{partial}"
-
-        template_formats = Array(args[1][:formats])
-        if template_formats.include?(:js)
+        template_formats = RailsViewAnnotator.extract_requested_formats_from(args)
+        if template_formats.include?(:text) # Do not render any comments for raw plaintext repsonses
+          return inner
+        elsif template_formats.include?(:js)
           comment_pattern = "/* begin: %{comment} */\n#{comment_pattern}/* end: %{comment} */"
         elsif template_formats.empty? || template_formats.include?(:html)
           comment_pattern = "<!-- begin: %{comment} -->\n#{comment_pattern}<!-- end: %{comment} -->"


### PR DESCRIPTION
In most contexts we do not know how the plaintext being rendered will be displayed, it can actually ruin the presentation.

It is therefore safer to omit the annotations if we know that the render is plaintext by design (like in plain e-mails)

To make it work we also need a different way of extracting the format from the render arguments.
