### PR TITLE
Made the gem augment actionview by subclassing

### DIFF
--- a/lib/rails_view_annotator.rb
+++ b/lib/rails_view_annotator.rb
@@ -1,3 +1,1 @@
-require 'rails_view_annotator/action_view/partial_renderer'
-
-RailsViewAnnotator.augment_partial_renderer ActionView::PartialRenderer
+require 'rails_view_annotator/action_view/renderer'

--- a/lib/rails_view_annotator/action_view/renderer.rb
+++ b/lib/rails_view_annotator/action_view/renderer.rb
@@ -1,0 +1,10 @@
+require 'action_view/renderer/renderer'
+require 'rails_view_annotator/partial_renderer'
+
+module ActionView
+  class Renderer
+    def render_partial(context, options, &block) #:nodoc:
+      RailsViewAnnotator::PartialRenderer.new(@lookup_context).render(context, options, block)
+    end
+  end
+end

--- a/lib/rails_view_annotator/partial_renderer.rb
+++ b/lib/rails_view_annotator/partial_renderer.rb
@@ -1,14 +1,16 @@
-module RailsViewAnnotator
-  # Tells for which formats the partial has been requested.
-  def self.extract_requested_formats_from(render_arguments)
-    lookup_context = render_arguments[0].lookup_context
-    lookup_context.formats
-  end
+require 'action_view/renderer/partial_renderer'
 
-  def self.augment_partial_renderer klass
-    stock_render = klass.instance_method :render
-    klass.send(:define_method, :render) do |*args|
-      inner = stock_render.bind(self).call(*args)
+module RailsViewAnnotator
+  class PartialRenderer < ActionView::PartialRenderer
+    # Tells for which formats the partial has been requested.
+    def extract_requested_formats_from(context)
+      lookup_context = context.lookup_context
+      lookup_context.formats
+    end
+
+    def render(context, options, block)
+      inner = super
+      identifier = template_identifier
 
       return unless identifier
 
@@ -16,13 +18,13 @@ module RailsViewAnnotator
 
       r = /^#{Regexp.escape(Rails.root.to_s)}\/([^:]+:\d+)/
       caller.find { |line| line.match r }
-      called_from = context = $1
+      called_from = $1
 
       descriptor = "#{short_identifier} (from #{called_from})"
 
       if inner.present?
         comment_pattern = "%{partial}"
-        template_formats = RailsViewAnnotator.extract_requested_formats_from(args)
+        template_formats = extract_requested_formats_from(context)
         if template_formats.include?(:text) # Do not render any comments for raw plaintext repsonses
           return inner
         elsif template_formats.include?(:js)
@@ -34,11 +36,10 @@ module RailsViewAnnotator
         (comment_pattern % {:partial => inner, :comment => descriptor}).html_safe
       end
     end
-    klass.send(:include, InstanceMethods)
-  end
 
-  module InstanceMethods
-    def identifier
+    protected
+
+    def template_identifier
       (@template = find_partial) ? @template.identifier : @path
     end
   end


### PR DESCRIPTION
I've made the gem load by subclassing rails' own partial renderer, then overriding the `render_partial` method to use the rails view annotator renderer instead. Loading it this way seems nicer and less prone to break if rails changes it's api.
