### PR TITLE
Stopped using the global variable $1 global

### DIFF
--- a/lib/rails_view_annotator/action_view/partial_renderer.rb
+++ b/lib/rails_view_annotator/action_view/partial_renderer.rb
@@ -15,8 +15,14 @@ module RailsViewAnnotator
       short_identifier = Pathname.new(identifier).relative_path_from Rails.root
 
       r = /^#{Regexp.escape(Rails.root.to_s)}\/([^:]+:\d+)/
-      caller.find { |line| line.match r }
-      called_from = context = $1
+      called_from = context = nil
+      caller.each do |line|
+        m = line.match(r)
+        unless m.nil?
+          called_from = context = m[1]
+          break
+        end
+      end
 
       descriptor = "#{short_identifier} (from #{called_from})"
 


### PR DESCRIPTION
It's a bad practice, plus it might cause problems with multithreaded code
