### PR TITLE
Make template_format checking use a whitelist

### DIFF
--- a/lib/rails_view_annotator/action_view/partial_renderer.rb
+++ b/lib/rails_view_annotator/action_view/partial_renderer.rb
@@ -23,12 +23,12 @@ module RailsViewAnnotator
       if inner.present?
         comment_pattern = "%{partial}"
         template_formats = RailsViewAnnotator.extract_requested_formats_from(args)
-        if template_formats.include?(:text) # Do not render any comments for raw plaintext repsonses
-          return inner
-        elsif template_formats.include?(:js)
+        if template_formats == [:js]
           comment_pattern = "/* begin: %{comment} */\n#{comment_pattern}/* end: %{comment} */"
-        elsif template_formats.empty? || template_formats.include?(:html)
+        elsif template_formats == [:html]
           comment_pattern = "<!-- begin: %{comment} -->\n#{comment_pattern}<!-- end: %{comment} -->"
+        else
+          return inner # Do not render any comments for responses we do not support
         end
 
         (comment_pattern % {:partial => inner, :comment => descriptor}).html_safe


### PR DESCRIPTION
Code such as the follow contains :html in the
template_formats list, but is made invalid if a html
comment is appended to it.

```ruby
render(
  partial: 'scss partial',
  locals: { main_color: '#f0f' },
  formats: :scss
)
```

I've changed the template_format checking code so that
it only applies the template when we are absoutely
certain that the template is in the expected format.